### PR TITLE
Relax project requirement.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 bin/*
+vendor
 Dockerfile.cross
 
 # Test binary, built with `go test -c`

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ First class vCluster support in Rancher
 
 ## Description
 
-Deploying a vCluster in rancher should provide the same great experience that provisioning any other cluster in Rancher would. vCluster Rancher Operator automatically integrates vCluster deployments with Rancher. This integration combines the great clusters management of Rancher with the security, cost-effectiveness, and speed of vClusters.
+Deploying a vCluster in Rancher should provide the same great experience that provisioning any other cluster in Rancher would. vCluster Rancher Operator automatically integrates vCluster deployments with Rancher. This integration combines the great clusters management of Rancher with the security, cost-effectiveness, and speed of vClusters.
 
 **Features**
-* creates a Rancher Cluster that corresponds to the vCluster
+* Creates a Rancher Cluster that corresponds to the vCluster.
 * Rancher users do not need cluster management permissions. The operator will create the Rancher cluster.
 * Project owners and project members of the virtual cluster's project, as well as the cluster owner, will be added to the new Rancher cluster as cluster owners.
 
@@ -22,7 +22,7 @@ To install vCluster Rancher Operator, you can add the loft repository to Rancher
 2. In the sidebar, navigate to "Apps" -> "Repositories".
 3. Select "Create".
 4. Set the name to any value and the Index URL to `https://charts.loft.sh`.
-5. (Optional) if you want to install pre-release versions you must select the user icon in the top right, then navigate to "Preferences". Scroll down and select "Include Prerelease Versions".
+5. (Optional) If you want to install pre-release versions you must select the user icon in the top right, then navigate to "Preferences". Scroll down and select "Include Prerelease Versions".
 6. In the sidebar, navigate to "Apps" -> "Charts".
 7. Find and select the "vCluster Rancher Operator" chart.
 8. Follow the installation process and install the chart.
@@ -37,12 +37,12 @@ Once the operator is installed, all vClusters deployed in any downstream cluster
 
 ## Technical Details
 
-The vCluster Rancher operator run in the local cluster and watches clusters.management.cattle.io. When a cluster has not been seen by the handler before,
-it creates a client using the Rancher reverse proxy to talk to the downstream cluster. This is done by creating a token, if needed, for the user.management.cattle.io
+The vCluster Rancher operator runs in the local cluster and watches `clusters.management.cattle.io`. When a cluster has not been seen by the handler before,
+it creates a client using the Rancher reverse proxy to talk to the downstream cluster. This is done by creating a token, if needed, for the `user.management.cattle.io`
 that is created during the Helm chart install. The token is then used to authenticate requests to the Rancher proxy.
 
 Once a client is created for a downstream cluster, it is used to watch all services with the label `app=vcluster`. If the vCluster install does not have a corresponding
-Rancher cluster, the installation process begins. The installation process creates a provisioning clusters, waits for Rancher to create the clusterregistrationtoken.cattle.io,
+Rancher cluster, the installation process begins. The installation process creates a provisioning clusters, waits for Rancher to create the `clusterregistrationtoken.cattle.io`,
 and then extracts the command from the clusterregistrationtokens status. This command contains everything that is needed to deploy Rancher's cluster agent to the vCluster. A
 job is then deployed in the vCluster's host cluster that creates a kubeconfig pointing the the vCluster service in the host cluster. The earlier extracted command is executed
 using the newly created kubeconfig.
@@ -52,19 +52,69 @@ project-owner or project-member roles are added as cluster owners, using a clust
 
 Deletion events for the vCluster service will trigger the controller to delete the corresponding Rancher cluster.
 
+```mermaid
+sequenceDiagram
+    participant Op as vCluster Rancher Operator
+    participant LAPI as Local Cluster API Server
+    participant R as Rancher Server<br/>(management)
+    participant RP as Rancher Reverse Proxy
+    participant DS as Downstream Cluster (vCluster)
+    participant HK as vCluster Host Cluster (K8s)
+    participant J as Kubernetes Job<br/>(runs in host cluster)
+    participant P as Rancher Project
+    participant U as Rancher Users
+
+    Op->>LAPI: Watch clusters.management.cattle.io
+    opt Cluster not seen before
+        Op->>R: Ensure `user.management.cattle.io` exists (from Helm install)
+        Op->>R: Create/ensure Token for the user
+        R-->>Op: Token
+        Op->>RP: Create client via Rancher proxy using Token
+        RP-->>Op: Authenticated client for downstream cluster
+    end
+
+    Op->>DS: Using client: Watch Services with label `app=vcluster`
+
+    opt vCluster has NO corresponding Rancher Cluster
+        Note over Op: Begin installation/registration flow
+        Op->>R: Create provisioning.cattle.io/Cluster
+        Op->>R: Wait for clusterregistrationtoken.cattle.io to be created
+        R-->>Op: ClusterRegistrationToken.status.command (install command)
+        Op->>HK: Create Job to perform registration
+        activate J
+        J->>HK: Generate kubeconfig targeting vCluster Service in host cluster
+        J->>DS: Execute extracted command using generated kubeconfig<br/>(deploy Rancher cluster agent)
+        deactivate J
+        R-->>Op: Downstream cluster connected (agent online)
+    end
+
+    opt 
+        Op->>HK: Determine which Project the vCluster is installed in
+        Op->>R: List projectroletemplatebinding.cattle.io in Project P
+        R-->>Op: Users with roles project-owner or project-member
+        loop For each eligible user
+            Op->>R: Create/ensure clusterroletemplatebinding.management.cattle.io<br/>granting cluster-owner on the vCluster Rancher Cluster
+        end
+        R-->>U: Users now have owner access to the vCluster Rancher Cluster
+    end
+
+    DS-->>Op: Service deletion event (app=vcluster)
+    Op->>R: Delete corresponding Rancher Cluster
+    R-->>Op: Cluster removed (agents cleaned up)
+```
+
 ## Development
 
 ### General Prerequisites
-- docker
-- devespace
-- rancher installed
-- access to local cluster in rancher
+- [Docker](https://www.docker.com/)
+- [DevSpace](https://www.devspace.sh/)
+- [Rancher](https://ranchermanager.docs.rancher.com/) installed with access to local cluster in rancher.
 
 ### To Deploy on the Rancher local cluster
 
 1. Download kubeconfig for rancher's local cluster from rancher, if you do not have direct access. This will be the case for docker installs of rancher.
 2. Point the `KUBECONFIG` environment variable to the rancher local cluster's kubeconfig path.
-3. Deploy the vcluster rancher operator using one of the following methods:
+3. Deploy the vCluster Rancher operator using one of the following methods:
 
 **Deploy the manager using devspace**
 
@@ -73,6 +123,26 @@ Note: This is the recommended way to develop on vcluster-rancher-operator
 ```shell
 devspace dev
 ```
+
+### 💡 Remote debugging
+Once devspace has started and opened a shell, the command history will contain a regular `go run` command as well as a `dlv` ([Delve](https://github.com/go-delve/delve))
+debugger command set to listen on port `2345`.  To be able to use remote debugging you'll need to be able to reach that port wherever the operator is running.  For example
+if you have a managed Kubernetes cluster in DigitalOcean, you'd just need to create a [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
+Service with a ports section like
+
+```yaml
+spec:
+  ports:
+  - name: whatever-name-youd-like 
+    port: 2345 
+    protocol: TCP
+    targetPort: 2345 
+  selector:
+    control-plane: vcluster-rancher-operator # label set in manager.yaml for the Deployment 
+  sessionAffinity: None
+  type: LoadBalancer 
+```
+
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
@@ -82,13 +152,13 @@ make docker-build docker-push IMG=<some-registry>/vcluster-rancher-operator:tag
 **Deploy the Manager to the cluster using Helm**
 
 ```sh
-KUBECONFIG=/home/ricardo/dev/rancher-integration/temp-kc.yaml helm install chart --generate-name --create-namespace
+KUBECONFIG=/path/to/rancher/host-cluster-kubeconfig.yaml helm install chart --generate-name --create-namespace
 ```
 
 **Deploy the Manager to the cluster with a custom image**
 
 ```sh
-KUBECONFIG=/home/ricardo/dev/rancher-integration/temp-kc.yaml helm install chart --generate-name --create-namespace --set image.registry=<REGISTRY> --set image.repository=<REPO/REPO> --set tag=<TAG>
+KUBECONFIG=/path/to/rancher/host-cluster-kubeconfig.yaml helm install chart --generate-name --create-namespace --set image.registry=<REGISTRY> --set image.repository=<REPO/REPO> --set tag=<TAG>
 ```
 
 ### Update RBAC for installed service account

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To install vCluster Rancher Operator, you can add the loft repository to Rancher
 6. In the sidebar, navigate to "Apps" -> "Charts".
 7. Find and select the "vCluster Rancher Operator" chart.
 8. Follow the installation process and install the chart.
+   * 💡 For development with DevSpace, name the installation "app", to match the deployment in `devspace.yaml`.
 9. In the sidebar, navigate to "Workloads" -> "Deployments". Confirm that the deployment named "vcluster-rancher-operator" has the State "Active".
 
 Once the operator is installed, all vClusters deployed in any downstream cluster in rancher will cause a corresponding Rancher cluster to be created, the vCluster to connect to the corresponding Rancher cluster, and cluster owners added.

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,16 +1,13 @@
 version: v2beta1
 name: vcluster-rancher-operator
 
-# This is a list of `pipelines` that DevSpace can execute (you can define your own)
 pipelines:
-  # This is the pipeline for the main command: `devspace dev` (or `devspace run-pipeline dev`)
   dev:
     run: |-
       run_dependencies --all       # 1. Deploy any projects this project needs (see "dependencies")
       ensure_pull_secrets --all    # 2. Ensure pull secrets
       create_deployments --all     # 3. Deploy Helm charts and manifests specfied as "deployments"
       start_dev app                # 4. Start dev mode "app" (see "dev" section)
-  # You can run this pipeline via `devspace deploy` (or `devspace run-pipeline deploy`)
   deploy:
     run: |-
       run_dependencies --all                            # 1. Deploy any projects this project needs (see "dependencies")
@@ -18,19 +15,9 @@ pipelines:
       build_images --all -t $(git describe --always)    # 3. Build, tag (git commit hash) and push all images (see "images")
       create_deployments --all                          # 4. Deploy Helm charts and manifests specfied as "deployments"
 
-# This is a list of `images` that DevSpace can build for this project
-# We recommend to skip image building during development (devspace dev) as much as possible
-images:
-  app:
-    image: controller
-    tags:
-    - 'v0.0.1-rc1'
-    dockerfile: ./Dockerfile
-
 # This is a list of `deployments` that DevSpace can create for this project
 deployments:
   app:
-    namespace: system
     helm:
       chart:
        name: ./chart
@@ -39,7 +26,7 @@ deployments:
 dev:
   app:
     # Search for the container that runs this image
-    imageSelector: ghcr.io/loft-sh/vcluster-rancher-operator:0.0.2
+    imageSelector: ghcr.io/loft-sh/vcluster-rancher-operator
     # Replace the container image with this dev-optimized image (allows to skip image building during development)
     devImage: ghcr.io/loft-sh/devspace-containers/go:1.23-alpine
     # Sync files between the local filesystem and the development container
@@ -49,7 +36,6 @@ dev:
     # Open a terminal and use the following command to start it
     terminal:
       command: ./devspace_start.sh
-    # Inject a lightweight SSH server into the container (so your IDE can connect to the remote dev env)
     ssh:
       enabled: true
     # Make the following commands from my local machine available inside the dev container
@@ -58,21 +44,5 @@ dev:
       - command: kubectl
       - command: helm
       - gitCredentials: true
-    # Forward the following ports to be able access your application via localhost
     ports:
-      - port: "2345"
-
-# Use the `commands` section to define repeatable dev workflows for this project 
-commands:
-  migrate-db:
-    command: |-
-      echo 'This is a cross-platform, shared command that can be used to codify any kind of dev task.'
-      echo 'Anyone using this project can invoke it via "devspace run migrate-db"'
-
-# Define dependencies to other projects with a devspace.yaml
-# dependencies:
-#   api:
-#     git: https://...  # Git-based dependencies
-#     tag: v1.0.0
-#   ui:
-#     path: ./ui        # Path-based dependencies (for monorepos)
+      - port: 23450:2345

--- a/devspace_start.sh
+++ b/devspace_start.sh
@@ -27,10 +27,17 @@ This is how you can work with it:
 
 # Set terminal prompt
 export PS1="\[${COLOR_BLUE}\]devspace\[${COLOR_RESET}\] ./\W \[${COLOR_BLUE}\]\\$\[${COLOR_RESET}\] "
+COMMAND_RUN='go run -mod vendor cmd/main.go'
+COMMAND_DEBUG='dlv debug ./cmd/main.go --listen=0.0.0.0:2345 --api-version=2 --output /tmp/__debug_bin --headless --build-flags=-mod=vendor'
 if [ -z "$BASH" ]; then export PS1="$ "; fi
 
 # Include project's bin/ folder in PATH
 export PATH="./bin:$PATH"
+
+export HISTFILE=/tmp/.bash_history
+history -s "$COMMAND_DEBUG"
+history -s "$COMMAND_RUN"
+history -a
 
 # Open shell
 bash --norc

--- a/internal/controller/clusters/cluster_controller.go
+++ b/internal/controller/clusters/cluster_controller.go
@@ -97,41 +97,29 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	restConfig, err := token.RestConfigFromToken(managementCluster.GetName(), r.RancherToken)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	cleanupErr := r.SyncCleanup(ctx, logger, managementCluster)
+	rbacErr := r.SyncRancherRBAC(ctx, logger, managementCluster)
+	installErr := r.SyncvClusterInstallHandler(ctx, logger, managementCluster.GetName())
 
-	clusterClient, unstructClusterClient, err := getClusterClient(restConfig)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = r.SyncCleanup(ctx, logger, managementCluster)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = r.SyncRancherRBAC(ctx, logger, managementCluster)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	err = r.SyncvClusterInstallHandler(ctx, logger, clusterClient, unstructClusterClient, managementCluster.GetName())
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, errors.Join(cleanupErr, rbacErr, installErr)
 }
 
-func (r *ClusterReconciler) SyncvClusterInstallHandler(ctx context.Context, logger logr.Logger, clusterClient *kubernetes.Clientset, unstructuredClusterClient unstructured.Client, clusterName string) error {
+func (r *ClusterReconciler) SyncvClusterInstallHandler(ctx context.Context, logger logr.Logger, clusterName string) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	_, ok := r.peers[clusterName]
 
-	if ok {
+	if _, ok := r.peers[clusterName]; ok {
 		return nil
+	}
+
+	restConfig, err := token.RestConfigFromToken(clusterName, r.RancherToken)
+	if err != nil {
+		return err
+	}
+
+	clusterClient, unstructuredClusterClient, err := getClusterClient(restConfig)
+	if err != nil {
+		return err
 	}
 
 	sharedInformer := cache.NewSharedInformer(&cache.ListWatch{
@@ -145,7 +133,7 @@ func (r *ClusterReconciler) SyncvClusterInstallHandler(ctx context.Context, logg
 		},
 	}, &corev1.Service{}, 0)
 
-	_, err := sharedInformer.AddEventHandler(&services.Handler{
+	_, err = sharedInformer.AddEventHandler(&services.Handler{
 		Ctx:                       ctx,
 		Logger:                    logger,
 		LocalUnstructuredClient:   r.Client,
@@ -364,7 +352,7 @@ func (r *ClusterReconciler) SyncCleanup(ctx context.Context, logger logr.Logger,
 	}
 
 	if resp.StatusCode != http.StatusOK && obj.Code != "NotFound" {
-		return errors.New("app uninstall failed for app")
+		return errors.New("app uninstall failed")
 	}
 
 	logger.Info("cleaning up...")
@@ -375,8 +363,9 @@ func (r *ClusterReconciler) SyncCleanup(ctx context.Context, logger logr.Logger,
 
 	for index, value := range managementCluster.GetFinalizers() {
 		if value == constants.FinalizerVClusterApp {
+			orig := managementCluster.DeepCopy()
 			managementCluster.SetFinalizers(slices.Delete(managementCluster.GetFinalizers(), index, index+1))
-			err = r.Client.Update(ctx, &managementCluster)
+			err = r.Client.Patch(ctx, &managementCluster, client.MergeFrom(orig))
 			if err != nil && !kerrors.IsNotFound(err) {
 				return fmt.Errorf("failed to remov")
 			}

--- a/internal/controller/clusters/cluster_controller.go
+++ b/internal/controller/clusters/cluster_controller.go
@@ -204,7 +204,9 @@ func (r *ClusterReconciler) SyncRancherRBAC(ctx context.Context, logger logr.Log
 		if projectUID == constants.NoRancherProjectOnNameSpace {
 			return nil
 		}
-		return errors.New("vCluster management cluster missing at least 1 vCluster label(s)")
+		logger.Info(fmt.Sprintf("vCluster management cluster %q missing at least 1 vCluster label(s)", managementCluster.GetName()))
+
+		return nil
 	}
 
 	project, err := r.Client.Get(ctx, gvk.ProjectManagementCattle, projectName, hostClusterName)
@@ -387,10 +389,15 @@ func (r *ClusterReconciler) SyncCleanup(ctx context.Context, logger logr.Logger,
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		Watches(&v1unstructured.Unstructured{Object: map[string]interface{}{"kind": "ProjectRoleTemplateBinding", "apiVersion": "management.cattle.io/v3"}}, handler.EnqueueRequestsFromMapFunc(r.clustersRelatedToTargetProject), builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
-		Watches(&v1unstructured.Unstructured{Object: map[string]interface{}{"kind": "ClusterRoleTemplateBinding", "apiVersion": "management.cattle.io/v3"}}, handler.EnqueueRequestsFromMapFunc(r.clustersHostedByClusterTarget), builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
-		// Uncomment the following line adding a pointer to an instance of the controlled resource as an argument
-		For(&v1unstructured.Unstructured{Object: map[string]interface{}{"kind": "Cluster", "apiVersion": "management.cattle.io/v3"}}).
+		Watches(gvk.ToUnstructured(gvk.ProjectRoleTemplateBindingManagementCattle),
+			handler.EnqueueRequestsFromMapFunc(r.clustersRelatedToTargetProject),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
+		Watches(gvk.ToUnstructured(gvk.ClusterRoleTemplateBindingManagementCattle),
+			handler.EnqueueRequestsFromMapFunc(r.clustersHostedByClusterTarget),
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{}),
+		).
+		For(gvk.ToUnstructured(gvk.ClustersManagementCattle)).
 		Named("cluster").
 		Complete(r)
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,17 @@
+package constants
+
+const (
+	AnnotationSkipImport           = "loft.sh/vcluster-skip-import"
+	AnnotationUninstallOnDelete    = "loft.sh/uninstall-on-cluster-delete"
+	NoRancherProjectOnNameSpace    = "no-rancher-project-on-namespace"
+	LabelProjectUID                = "loft.sh/vcluster-project-uid"
+	LabelProjectName               = "loft.sh/vcluster-project"
+	LabelHostClusterName           = "loft.sh/vcluster-host-cluster"
+	LabelVClusterServiceUID        = "loft.sh/vcluster-service-uid"
+	LabelParentRoleTemplateBinding = "loft.sh/parent-prtb"
+	LabelChildRoleTemplateBinding  = "loft.sh/parent-crtb"
+	LabelTargetApp                 = "loft.sh/target-app"
+	LabelRancherSystemToken        = "loft.sh/vcluster-rancher-system-token"
+	LabelVClusterRancherUser       = "loft.sh/vcluster-rancher-user"
+	FinalizerVClusterApp           = "loft.sh/vcluster-app-cleanup"
+)

--- a/pkg/services/handler.go
+++ b/pkg/services/handler.go
@@ -88,7 +88,7 @@ func (h *Handler) deployvClusterRancherCluster(obj interface{}) error {
 		return nil
 	}
 
-	provisioningCluster, err := h.LocalUnstructuredClient.GetFirstWithLabel(h.Ctx, gvk.ProjectManagementCattle, constants.LabelVClusterServiceUID, string(service.GetUID()))
+	provisioningCluster, err := h.LocalUnstructuredClient.GetFirstWithLabel(h.Ctx, gvk.ClusterProvisioningCattle, constants.LabelVClusterServiceUID, string(service.GetUID()))
 	if client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("error getting provisioning cluster for vCluster instance: %w", err)
 	}

--- a/pkg/services/handler.go
+++ b/pkg/services/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -95,18 +96,23 @@ func (h *Handler) deployvClusterRancherCluster(obj interface{}) error {
 
 	if kerrors.IsNotFound(err) {
 		logger.Info("provisioning cluster does not exist for vCluster instance, creating...")
-		project, err := h.LocalUnstructuredClient.Get(h.Ctx, gvk.ClusterProvisioningCattle, ns.GetLabels()["field.cattle.io/projectId"], h.ClusterName)
+
 		labels := map[string]string{
 			constants.LabelVClusterServiceUID: string(service.GetUID()),
 			constants.LabelHostClusterName:    h.ClusterName,
 		}
 
-		if err != nil {
-			logger.Error(err, "get project for vCluster service")
-			labels[constants.LabelProjectUID] = constants.NoRancherProjectOnNameSpace
-		} else {
+		projectID, hasProjectID := ns.GetLabels()["field.cattle.io/projectId"]
+		if hasProjectID {
+			project, err := h.LocalUnstructuredClient.Get(h.Ctx, gvk.ProjectManagementCattle, projectID, h.ClusterName)
+			if err != nil {
+				return fmt.Errorf("failed to get project for vCluster's namespace [%s]: %w", service.Namespace, err)
+			}
+
 			labels[constants.LabelProjectUID] = string(project.GetUID())
 			labels[constants.LabelProjectName] = project.GetName()
+		} else {
+			labels[constants.LabelProjectUID] = constants.NoRancherProjectOnNameSpace
 		}
 
 		provisioningCluster, err = h.LocalUnstructuredClient.Create(
@@ -131,7 +137,7 @@ func (h *Handler) deployvClusterRancherCluster(obj interface{}) error {
 	err = wait.ExponentialBackoff(wait.Backoff{Duration: 100 * time.Millisecond, Steps: 20, Factor: 1.5},
 		// the use of a backoff retry here is justifiable because we are not using a normal framework that will retry on error on our behalf.
 		func() (bool, error) {
-			logger.Info("waiting for rancher to create management cluster for vCluster")
+			logger.Info(fmt.Sprintf("waiting for rancher to create management cluster for vCluster %q: %q", service.Name, service.GetUID()))
 			managementCluster, err = h.LocalUnstructuredClient.GetFirstWithLabel(h.Ctx, gvk.ClustersManagementCattle, constants.LabelVClusterServiceUID, string(service.GetUID()))
 			if err != nil {
 				if kerrors.IsNotFound(err) {
@@ -141,17 +147,25 @@ func (h *Handler) deployvClusterRancherCluster(obj interface{}) error {
 			}
 			logger.Info("successfully retrieved management cluster for vCluster")
 
+			orig := managementCluster.DeepCopy()
+			// If the annotation is set and the finalizer is not present, add it along with the target app label
+			// Otherwise, remove the finalizer
 			if service.GetAnnotations()[constants.AnnotationUninstallOnDelete] == "true" {
-				managementCluster.SetFinalizers([]string{constants.FinalizerVClusterApp})
+				managementCluster.SetFinalizers(append(managementCluster.GetFinalizers(), constants.FinalizerVClusterApp))
+
 				// for some reason setting annotations on the management cluster before its admission webhook deploys stops the agent from installing, so a label is used here
-				managementCluster.SetLabels(map[string]string{constants.LabelTargetApp: fmt.Sprintf("%s_%s", service.Annotations["meta.helm.sh/release-namespace"], service.Annotations["meta.helm.sh/release-name"])})
-				err = h.LocalUnstructuredClient.Update(h.Ctx, &managementCluster)
-				if err != nil {
-					if kerrors.IsConflict(err) {
-						return false, nil
-					}
-					return false, fmt.Errorf("failed to add ap cleanup finalizer %q to management cluster: %w", constants.AnnotationUninstallOnDelete, err)
+				labels := managementCluster.GetLabels()
+				labels[constants.LabelTargetApp] = fmt.Sprintf("%s_%s", service.Annotations["meta.helm.sh/release-namespace"], service.Annotations["meta.helm.sh/release-name"])
+				managementCluster.SetLabels(labels)
+			} else if idx := slices.Index(managementCluster.GetFinalizers(), constants.FinalizerVClusterApp); idx >= 0 {
+				managementCluster.SetFinalizers(slices.Delete(managementCluster.GetFinalizers(), idx, idx+1))
+			}
+
+			if err := h.LocalUnstructuredClient.Patch(h.Ctx, &managementCluster, client.MergeFrom(orig)); err != nil {
+				if kerrors.IsConflict(err) {
+					return false, nil
 				}
+				return false, fmt.Errorf("failed to add app cleanup finalizer %q to management cluster: %w", constants.AnnotationUninstallOnDelete, err)
 			}
 
 			logger.Info("waiting for rancher to create cluster registration token for vCluster")

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/loft-sh/vcluster-rancher-operator/pkg/constants"
 	"github.com/loft-sh/vcluster-rancher-operator/pkg/rancher"
 	"github.com/loft-sh/vcluster-rancher-operator/pkg/unstructured"
 	"github.com/loft-sh/vcluster-rancher-operator/pkg/unstructured/gvk"
@@ -21,7 +22,7 @@ type data struct {
 }
 
 func GetToken(ctx context.Context, client unstructured.Client) (string, error) {
-	tokenList, err := client.ListWithLabel(ctx, gvk.TokenManagementCattle, "loft.sh/vcluster-rancher-system-token", "true")
+	tokenList, err := client.ListWithLabel(ctx, gvk.TokenManagementCattle, constants.LabelRancherSystemToken, "true")
 	if err != nil {
 		return "", err
 	}
@@ -33,7 +34,7 @@ func GetToken(ctx context.Context, client unstructured.Client) (string, error) {
 		}
 	}
 
-	systemUser, err := client.GetFirstWithLabel(ctx, gvk.UserManagementCattle, "loft.sh/vcluster-rancher-user", "true")
+	systemUser, err := client.GetFirstWithLabel(ctx, gvk.UserManagementCattle, constants.LabelVClusterRancherUser, "true")
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +50,7 @@ func GetToken(ctx context.Context, client unstructured.Client) (string, error) {
 		"token-vcluster-rancher-operator",
 		"",
 		false,
-		map[string]string{"loft.sh/vcluster-rancher-system-token": "true"},
+		map[string]string{constants.LabelRancherSystemToken: "true"},
 		nil,
 		map[string]interface{}{
 			"authProvider": "local",

--- a/pkg/unstructured/client.go
+++ b/pkg/unstructured/client.go
@@ -49,7 +49,7 @@ func (c *Client) List(ctx context.Context, gvk schema.GroupVersionKind, namespac
 	if namespace != "" {
 		return c.ListWithOptions(ctx, gvk, &client.ListOptions{Namespace: namespace})
 	}
-	return c.ListWithOptions(ctx, gvk, nil)
+	return c.ListWithOptions(ctx, gvk, &client.ListOptions{})
 }
 
 func (c *Client) ListWithOptions(ctx context.Context, gvk schema.GroupVersionKind, options *client.ListOptions) (unstructured.UnstructuredList, error) {

--- a/pkg/unstructured/gvk/gvk.go
+++ b/pkg/unstructured/gvk/gvk.go
@@ -5,11 +5,10 @@ import "k8s.io/apimachinery/pkg/runtime/schema"
 var (
 	ClustersManagementCattle                   = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Cluster"}
 	ProjectManagementCattle                    = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Project"}
-	TokenManagementCattle                      = schema.GroupVersionKind{Kind: "token", Group: "management.cattle.io", Version: "v3"}
-	UserManagementCattle                       = schema.GroupVersionKind{Kind: "User", Group: "management.cattle.io", Version: "v3"}
+	TokenManagementCattle                      = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Token"}
+	UserManagementCattle                       = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "User"}
 	ProjectRoleTemplateBindingManagementCattle = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "ProjectRoleTemplateBinding"}
 	ClusterRoleTemplateBindingManagementCattle = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "ClusterRoleTemplateBinding"}
 	ClusterRegistrationTokenManagementCattle   = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "ClusterRegistrationToken"}
-
-	ClusterProvisioningCattle = schema.GroupVersionKind{Group: "provisioning.cattle.io", Version: "v1", Kind: "Cluster"}
+	ClusterProvisioningCattle                  = schema.GroupVersionKind{Group: "provisioning.cattle.io", Version: "v1", Kind: "Cluster"}
 )

--- a/pkg/unstructured/gvk/gvk.go
+++ b/pkg/unstructured/gvk/gvk.go
@@ -1,6 +1,9 @@
 package gvk
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+import (
+	v1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
 
 var (
 	ClustersManagementCattle                   = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "Cluster"}
@@ -12,3 +15,12 @@ var (
 	ClusterRegistrationTokenManagementCattle   = schema.GroupVersionKind{Group: "management.cattle.io", Version: "v3", Kind: "ClusterRegistrationToken"}
 	ClusterProvisioningCattle                  = schema.GroupVersionKind{Group: "provisioning.cattle.io", Version: "v1", Kind: "Cluster"}
 )
+
+func ToUnstructured(gvk schema.GroupVersionKind) *v1unstructured.Unstructured {
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	return &v1unstructured.Unstructured{
+		Object: map[string]any{
+			"kind":       kind,
+			"apiVersion": apiVersion,
+		}}
+}


### PR DESCRIPTION
Fixes ENG-7164, ENG-8019, ENG-7036

* Only look for a project when creating a provisioning cluster
* Don't require the project
* Update, rather than replace labels
* Adds several constants for annotations & labels
* Some devspace cleanup
  * Removes tag specificity for the image
  * Adds commands to history
  * removes some boiler plate 
  

## TODO
 * Tests